### PR TITLE
Fix enable_pin in example klipper config

### DIFF
--- a/doc/printer.cfg
+++ b/doc/printer.cfg
@@ -10,7 +10,7 @@ restart_method = command
 [extruder]
 step_pin: head0:PB3
 dir_pin: head0:PB4
-enable_pin: !head0:PB6
+enable_pin: !head0:PB5
 heater_pin: head0:PA6  # "HEAT"
 step_distance: .002
 nozzle_diameter: 0.400


### PR DESCRIPTION
I already had thought I fried my stepper driver... until I noticed the example config in the klipper repo used a different pin: https://github.com/Klipper3d/klipper/blob/df39465534dc8d0056774baceab8a3ee2676904a/config/sample-huvud-v0.61.cfg#L24